### PR TITLE
fix(scheduler): 修正调用 mcp 提供的 llm tool 时失败的问题

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -464,7 +464,7 @@ class ReminderScheduler:
                                 # 获取函数对象和处理器
                                 func_obj = func_tool.get_func(func_name)
                                 
-                                if func_obj and func_obj.handler:
+                                if func_obj:
                                     # 创建最小的事件对象来调用函数
                                     # 导入必要的类
                                     from astrbot.api.platform import AstrBotMessage, PlatformMetadata, MessageType, MessageMember
@@ -601,7 +601,11 @@ class ReminderScheduler:
                                         has_sent_message_before = event._has_send_oper
                                         
                                         # 调用函数
-                                        func_result = await func_obj.handler(event, **func_args)
+                                        if func_obj.handler:
+                                            func_result = await func_obj.handler(event, **func_args)
+                                        else:
+                                            func_result = await func_obj.execute(**func_args)
+                                        
                                         logger.info(f"函数调用结果: {func_result}")
                                         
                                         # 检查函数是否已经自己发送了消息


### PR DESCRIPTION
定时执行 mcp 提供的函数调用时，执行失败，错误：`找不到函数处理器`
原因是 mcp 提供的 func，handler 为空

```
@dataclass
class FuncTool:
    """
    用于描述一个函数调用工具。
    """

    name: str
    parameters: Dict
    description: str
    handler: Awaitable = None
    """处理函数, 当 origin 为 mcp 时，这个为空"""
    handler_module_path: str = None
    """处理函数的模块路径，当 origin 为 mcp 时，这个为空
```

```
 [08:57:00] [Plug] [INFO] [astrbot_plugin_sy.scheduler:326]: 开始执行任务: 调用llm函数 fetch，参数url为 www.baidu.com 在 aiocqhttp:FriendMessage:
 [08:57:00] [Plug] [INFO] [astrbot_plugin_sy.scheduler:375]: 已应用MessageSesion安全解析补丁 
 [08:57:00] [Plug] [INFO] [astrbot_plugin_sy.scheduler:383]: 使用提供商: openai_chat_completion 
 [08:57:00] [Plug] [INFO] [astrbot_plugin_sy.scheduler:387]: Task Activated: 调用llm函数 fetch，参数url为 www.baidu.com, attempting to execute for aiocqhttp:FriendMessage:
 [08:57:00] [Plug] [INFO] [astrbot_plugin_sy.scheduler:391]: LLM工具管理器加载成功: True 
 [08:57:00] [Plug] [INFO] [astrbot_plugin_sy.scheduler:406]: 提醒模式：找到用户对话，对话ID: , 上下文长度: 56 
 [08:57:00] [Plug] [INFO] [astrbot_plugin_sy.scheduler:424]: 发送提示词到LLM: 请执行以下任务：调用llm函数 fetch，参数url为 www.baidu.com。请直接执行，不... 
 [08:57:03] [Plug] [INFO] [astrbot_plugin_sy.scheduler:439]: LLM响应类型: tool 
 [08:57:03] [Plug] [INFO] [astrbot_plugin_sy.scheduler:451]: 检测到工具调用: ['fetch'] 
 [08:57:03] [Plug] [INFO] [astrbot_plugin_sy.scheduler:461]: 执行工具调用: fetch({'url': 'www.baidu.com'}) 
 [08:57:03] [Plug] [WARN] [astrbot_plugin_sy.scheduler:626]: 找不到函数处理器: fetch 
 [08:57:03] [Plug] [INFO] [astrbot_plugin_sy.scheduler:694]: 尝试发送消息到: aiocqhttp:FriendMessage:(原始ID: aiocqhttp:FriendMessage:) 
```

这个 PR 修正了上述问题