### PR TITLE
Update reminder_handlers.py 修复权限判别问题

### DIFF
--- a/reminder_handlers.py
+++ b/reminder_handlers.py
@@ -291,6 +291,14 @@ class TaskExecutor:
                 sender_id = reminder.get("creator_id", "unknown")
                 return str(sender_id) if sender_id else "unknown"
             event.get_sender_id = get_sender_id
+
+        # 设置 sender 身份
+        creator_id = str(reminder.get("creator_id"))
+        admin_ids = self.context._config.get("admins_id", [])
+        if creator_id and creator_id in admin_ids:
+            event.role = "admin"
+        else:
+            event.role = "member"
         
         # 添加结果管理方法，支持复杂消息类型
         if not hasattr(event, '_result'):


### PR DESCRIPTION

在使用 `ai_reminder` 插件创建定时提醒并触发LLM使用其他插件工具（以https://github.com/luosheng520qaq/astrobot_plugin_code_executor 为例）时，遇到了提醒的创建者是管理员时`Super Code Executor` 报告权限不足问题。
调试日志如下：

```
[20:52:00] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:394]: Task Activated: 扫描当前工作目录的文件名称以消息的形式发送给用户, attempting to execute for Astro:FriendMessage:434435

[20:52:00] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:221]: 已应用MessageSesion安全解析补丁

[20:52:00] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:430]: 发送提示词到LLM: 请执行以下任务：扫描当前工作目录的文件名称以消息的形式发送给用户。请直接执行，不要提及这是一个预设任...

[20:52:03] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:444]: LLM响应类型: tool

[20:52:03] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:516]: 检测到工具调用: ['execute_python_code']

[20:52:03] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:529]: 执行工具调用: execute_python_code({'code': 'import os\n\n# 获取当前工作目录\ncurrent_directory = os.getcwd()\n\n# 列出当前工作目录下的所有文件和文件夹\nfiles_and_folders = os.listdir(current_directory)\n\n# 将文件和文件夹名称以消息形式发送给用户\nfor item in files_and_folders:\n    print(item)', 'description': '扫描当前工作目录的文件名称并打印'})

[20:52:03] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:336]: 当前创建者的ID: 434435

[20:52:03] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:545]: 调用函数 execute_python_code:

[20:52:03] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:546]:   - func_args: {'code': 'import os\n\n# 获取当前工作目录\ncurrent_directory = os.getcwd()\n\n# 列出当前工作目录下的所有文件和文件夹\nfiles_and_folders = os.listdir(current_directory)\n\n# 将文件和文件夹名称以消息形式发送给用户\nfor item in files_and_folders:\n    print(item)', 'description': '扫描当前工作目录的文件名称并打印'}

[20:52:03] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:547]:   - event.unified_msg_origin: None:FriendMessage:434435

[20:52:03] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:548]:   - event.session_id: 434435

[20:52:03] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:549]:   - event.message_obj.group_id:

[20:52:03] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:550]:   - event.message_obj.self_id: astrbot_reminder

[20:52:03] [Plug] [INFO] [astrobot_plugin_code_executor.main:398]: 角色member

[20:52:03] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:558]: 函数调用结果类型: <class 'str'>, 值: ❌ 权限验证失败：用户不是管理员，无权限运行代码。请联系管理员获取权限。操作已终止，无需重复尝试。

```
**根本原因分析与初步解决方法：**

1.  **权限问题 (`event.role` 未正确设置):**
    *   `AstrMessageEvent` 对象在初始化时，`event.role` 默认为 `"member"`。
    *   在正常的 AstrBot 消息处理流水线中，`waking_check/stage.py` 阶段会检查消息发送者的 ID 是否在 `admins_id` 列表中。如果匹配，`event.role` 会被设置为 `"admin"`。
    *   `ai_reminder` 插件通过模拟事件来触发工具调用，这些模拟事件没有经过完整的 AstrBot 消息处理流水线，跳过了 `WakingCheckStage`。因此，`event.role` 始终保持为默认的 `"member"`，导致 `Super Code Executor` 的权限验证失败。

2.  **初步补丁：**

在`reminder_handlers.py`文件中的 `_ensure_event_attributes` 函数中单独添加权限判别代码。
在295行插入：

```
        # 设置 sender 身份
        creator_id = str(reminder.get("creator_id"))
        admin_ids = self.context._config.get("admins_id", [])
        if creator_id and creator_id in admin_ids:
            event.role = "admin"
        else:
            event.role = "member"
```

修复后再次尝试调试日志如下：

```
[21:29:00] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:401]: Task Activated: 扫描/LifeOS目录的文件名称以消息的形式发送给用户, attempting to execute for Astro:FriendMessage:434435

[21:29:00] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:221]: 已应用MessageSesion安全解析补丁

[21:29:00] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:437]: 发送提示词到LLM: 请执行以下任务：扫描/LifeOS目录的文件名称以消息的形式发送给用户。请直接执行，不要提及这是一个...

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:451]: LLM响应类型: tool

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:523]: 检测到工具调用: ['execute_python_code']

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:536]: 执行工具调用: execute_python_code({'code': 'import os\n\n# Define the directory to scan\ndirectory = \'/LifeOS\'\n\n# Check if the directory exists\nif not os.path.exists(directory):\n    print(f"Directory {directory} does not exist.")\nelse:\n    # List all files in the directory\n    files = os.listdir(directory)\n    \n    # Print the files as a message\n    if files:\n        print("Files in /LifeOS directory:")\n        for file in files:\n            print(file)\n    else:\n        print("No files found in /LifeOS directory.")', 'description': 'Scan the /LifeOS directory and list all file names'})

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:552]: 调用函数 execute_python_code:

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:553]:   - func_args: {'code': 'import os\n\n# Define the directory to scan\ndirectory = \'/LifeOS\'\n\n# Check if the directory exists\nif not os.path.exists(directory):\n    print(f"Directory {directory} does not exist.")\nelse:\n    # List all files in the directory\n    files = os.listdir(directory)\n    \n    # Print the files as a message\n    if files:\n        print("Files in /LifeOS directory:")\n        for file in files:\n            print(file)\n    else:\n        print("No files found in /LifeOS directory.")', 'description': 'Scan the /LifeOS directory and list all file names'}

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:554]:   - event.unified_msg_origin: None:FriendMessage:434435

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:555]:   - event.session_id: 434435

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:556]:   - event.message_obj.group_id:

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:557]:   - event.message_obj.self_id: astrbot_reminder

[21:29:05] [Plug] [INFO] [astrobot_plugin_code_executor.main:398]: 角色admin

[21:29:05] [Plug] [INFO] [astrobot_plugin_code_executor.main:402]: 收到任务: Scan the /LifeOS directory and list all file names

[21:29:05] [Plug] [INFO] [astrobot_plugin_code_executor.main:244]: 共找到 0 个图片URL

[21:29:05] [Plug] [INFO] [astrobot_plugin_code_executor.main:412]: 检测到 0 个图片URL: []

[21:29:05] [Plug] [WARN] [astrobot_plugin_code_executor.main:694]: 库 docx 不可用，相关功能禁用

[21:29:05] [Plug] [WARN] [astrobot_plugin_code_executor.main:694]: 库 psycopg2 不可用，相关功能禁用

[21:29:05] [Plug] [WARN] [astrobot_plugin_code_executor.main:694]: 库 cv2 不可用，相关功能禁用

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:565]: 函数调用结果类型: <class 'str'>, 值: ✅ 代码执行成功！任务已完全完成，无需再次执行。文件发送通过将路径添加到FILES_TO_SEND列表实现，一旦添加，文件将被自动处理和发送。

📤 执行结果：
Files in /LifeOS directory:

#recycle

.git

.makemd

.obsidian

.space

.stfolder

Tags

.ttxfolder

🎯 任务执行完毕，所有操作（包括文件发送）已成功完成。请停止进一步执行或调用此函数，避免重复。

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:569]: 函数 execute_python_code 已自行发送消息，不需要我们再发送

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:624]: 所有函数都已自行发送消息，不需要额外发送结果

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.reminder_handlers:484]: Task executed: 扫描/LifeOS目录的文件名称以消息的形式发送给用户

[21:29:05] [Plug] [WARN] [astrbot_plugin_sy.scheduler:393]: Failed to remove scheduler job reminder_Astro:FriendMessage:434435_2_20250921212837139: 'No job by the id of reminder_Astro:FriendMessage:434435_2_20250921212837139 was found'

[21:29:05] [Plug] [INFO] [astrbot_plugin_sy.scheduler:396]: One-time task removed: 扫描/LifeOS目录的文件名称以消息的形式发送给用户      
```